### PR TITLE
Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ e2e/coverage.html
 e2e/logs/
 # Generated config file (template is tracked)
 e2e/config.test.yaml
+node0
+node1
+node2
+config.yaml

--- a/cmd/mpcium/main.go
+++ b/cmd/mpcium/main.go
@@ -159,7 +159,7 @@ func runNode(ctx context.Context, c *cli.Command) error {
 	reshareResultQueue := mqManager.NewMessageQueue("mpc_reshare_result")
 	defer reshareResultQueue.Close()
 
-	logger.Info("Node is running", "id", nodeID, "name", nodeName)
+	logger.Info("Node is running", "ID", nodeID, "name", nodeName)
 
 	peerNodeIDs := GetPeerIDs(peers)
 	peerRegistry := mpc.NewRegistry(nodeID, peerNodeIDs, consulClient.KV())

--- a/pkg/eventconsumer/event_consumer.go
+++ b/pkg/eventconsumer/event_consumer.go
@@ -654,11 +654,11 @@ func (ec *eventConsumer) consumeReshareEvent() error {
 				return
 			}
 			newSession.ListenToIncomingMessageAsync()
-
 			// In resharing process, we need to ensure that the new session is aware of the old committee peers.
-			// Then new committee peers can start listening to the old committee peers, and thus enable receiving direct messages from them.
-			legacyCommitteePeers := newSession.GetLegacyCommitteePeers()
-			newSession.ListenToPeersAsync(legacyCommitteePeers)
+			// Then new committee peers can start listening to the old committee peers
+			// and thus enable receiving direct messages from them.
+			extraOldCommiteePeers := newSession.GetLegacyCommitteePeers()
+			newSession.ListenToPeersAsync(extraOldCommiteePeers)
 		}
 
 		ec.warmUpSession()

--- a/pkg/eventconsumer/event_consumer.go
+++ b/pkg/eventconsumer/event_consumer.go
@@ -657,8 +657,8 @@ func (ec *eventConsumer) consumeReshareEvent() error {
 
 			// In resharing process, we need to ensure that the new session is aware of the old committee peers.
 			// Then new committee peers can start listening to the old committee peers, and thus enable receiving direct messages from them.
-			extraOldCommiteePeers := newSession.GetExtraPeerIDs()
-			newSession.ListenAsyncWithExtra(extraOldCommiteePeers)
+			legacyCommitteePeers := newSession.GetLegacyCommitteePeers()
+			newSession.ListenToPeersAsync(legacyCommitteePeers)
 		}
 
 		ec.warmUpSession()

--- a/pkg/eventconsumer/keygen_consumer.go
+++ b/pkg/eventconsumer/keygen_consumer.go
@@ -149,7 +149,7 @@ func (sc *keygenConsumer) handleKeygenEvent(msg jetstream.Msg) {
 			break
 		}
 		if replyMsg != nil {
-			logger.Info("KeygenConsumer: Completed Keygen event; reply received")
+			logger.Info("KeygenConsumer: Completed keygen event; reply received")
 			if ackErr := msg.Ack(); ackErr != nil {
 				logger.Error("KeygenConsumer: ACK failed", ackErr)
 			}
@@ -157,7 +157,7 @@ func (sc *keygenConsumer) handleKeygenEvent(msg jetstream.Msg) {
 		}
 	}
 
-	logger.Warn("KeygenConsumer: Timeout waiting for Keygen event response")
+	logger.Warn("KeygenConsumer: Timeout waiting for keygen event response")
 	_ = msg.Nak()
 }
 

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -383,9 +383,6 @@ func (s *fileStore) DecryptMessage(cipher []byte, peerID string) ([]byte, error)
 	if key == nil {
 		return nil, fmt.Errorf("no symmetric key for peer %s", peerID)
 	}
-
-	// logger.Info("check decryption key", "final", key)
-
 	return decryptAEAD(key, cipher)
 }
 

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -1,8 +1,6 @@
 package identity
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
@@ -20,13 +18,11 @@ import (
 	"golang.org/x/term"
 
 	"github.com/fystack/mpcium/pkg/common/pathutil"
+	"github.com/fystack/mpcium/pkg/encryption"
 	"github.com/fystack/mpcium/pkg/logger"
 	"github.com/fystack/mpcium/pkg/types"
 	"github.com/spf13/viper"
 )
-
-const AES_GCM_Nonce_Size = 12
-const AES_SYMMETRICKEY_Size = 32
 
 // NodeIdentity represents a node's identity information
 type NodeIdentity struct {
@@ -64,12 +60,9 @@ type fileStore struct {
 	publicKeys map[string][]byte
 	mu         sync.RWMutex
 
-	// Cached private key
 	privateKey      []byte
 	initiatorPubKey []byte
-
-	//Cached ecdh symmetric key
-	symmetricKeys map[string][]byte
+	symmetricKeys   map[string][]byte
 }
 
 // NewFileStore creates a new identity store
@@ -310,56 +303,6 @@ func generateRandom(nonceSize int) ([]byte, error) {
 	return nonce, nil
 }
 
-// encryptAEAD encrypts plaintext using AES-GCM with authentication.
-func encryptAEAD(symmetricKey []byte, plaintext []byte) ([]byte, error) {
-	// Create AES cipher block
-	block, err := aes.NewCipher(symmetricKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
-	}
-
-	nonce, err := generateRandom(AES_GCM_Nonce_Size)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate nonce: %w", err)
-	}
-
-	aead, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create GCM: %w", err)
-	}
-
-	ciphertext := aead.Seal(nil, nonce, plaintext, nil)
-
-	return append(nonce, ciphertext...), nil
-}
-
-// decryptAEAD decrypts ciphertext using AES-GCM with authentication.
-func decryptAEAD(symmetricKey []byte, ciphertext []byte) ([]byte, error) {
-	block, err := aes.NewCipher(symmetricKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
-	}
-
-	aead, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create GCM: %w", err)
-	}
-
-	if len(ciphertext) < AES_GCM_Nonce_Size {
-		return nil, errors.New("ciphertext too short")
-	}
-	nonce := ciphertext[:AES_GCM_Nonce_Size]
-	ciphertext = ciphertext[AES_GCM_Nonce_Size:]
-
-	// Decrypt with no additional data (nil)
-	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
-	if err != nil {
-		return nil, fmt.Errorf("decryption failed: %w", err)
-	}
-
-	return plaintext, nil
-}
-
 func (s *fileStore) EncryptMessage(plaintext []byte, peerID string) ([]byte, error) {
 	key, err := s.GetSymmetricKey(peerID)
 	if err != nil {
@@ -370,7 +313,7 @@ func (s *fileStore) EncryptMessage(plaintext []byte, peerID string) ([]byte, err
 		return nil, fmt.Errorf("no symmetric key for peer %s", peerID)
 	}
 
-	return encryptAEAD(key, plaintext)
+	return encryption.EncryptAESGCMWithNonceEmbed(plaintext, key)
 }
 
 func (s *fileStore) DecryptMessage(cipher []byte, peerID string) ([]byte, error) {
@@ -383,7 +326,7 @@ func (s *fileStore) DecryptMessage(cipher []byte, peerID string) ([]byte, error)
 	if key == nil {
 		return nil, fmt.Errorf("no symmetric key for peer %s", peerID)
 	}
-	return decryptAEAD(key, cipher)
+	return encryption.DecryptAESGCMWithNonceEmbed(cipher, key)
 }
 
 // Sign ECDH key exchange message

--- a/pkg/messaging/point2point.go
+++ b/pkg/messaging/point2point.go
@@ -29,7 +29,8 @@ func NewNatsDirectMessaging(natsConn *nats.Conn) DirectMessaging {
 	}
 }
 
-// SendToSelf locally sends a message to the same node, invoking all handlers for the topic, avoiding mediating through the message layer.
+// SendToSelf locally sends a message to the same node, invoking all handlers for the topic
+// avoiding mediating through the message layer.
 func (d *natsDirectMessaging) SendToSelf(topic string, message []byte) error {
 	d.mu.Lock()
 	handlers, ok := d.handlers[topic]

--- a/pkg/mpc/ecdsa_resharing_session.go
+++ b/pkg/mpc/ecdsa_resharing_session.go
@@ -21,7 +21,7 @@ type ReshareSession interface {
 	Init() error
 	Reshare(done func())
 	GetPubKeyResult() []byte
-	GetExtraPeerIDs() []string
+	GetLegacyCommitteePeers() []string
 }
 
 type ecdsaReshareSession struct {
@@ -101,7 +101,7 @@ func NewECDSAReshareSession(
 
 	var oldPeerIDs []string
 	for _, partyId := range oldPartyIDs {
-		oldPeerIDs = append(oldPeerIDs, PartyIDToNodeID(partyId))
+		oldPeerIDs = append(oldPeerIDs, partyIDToNodeID(partyId))
 	}
 
 	return &ecdsaReshareSession{
@@ -114,8 +114,11 @@ func NewECDSAReshareSession(
 	}
 }
 
-func (s *ecdsaReshareSession) GetExtraPeerIDs() []string {
-	// difference returns elements in A that are not in B.
+// GetLegacyCommitteePeers returns peer IDs that were part of the old committee
+// but are NOT part of the new committee after resharing.
+// These peers are still relevant during resharing because
+// they must send final share data to the new committee.
+func (s *ecdsaReshareSession) GetLegacyCommitteePeers() []string {
 	difference := func(A, B []string) []string {
 		seen := make(map[string]bool)
 		for _, b := range B {

--- a/pkg/mpc/eddsa_resharing_session.go
+++ b/pkg/mpc/eddsa_resharing_session.go
@@ -91,7 +91,7 @@ func NewEDDSAReshareSession(
 
 	var oldPeerIDs []string
 	for _, partyId := range oldPartyIDs {
-		oldPeerIDs = append(oldPeerIDs, PartyIDToNodeID(partyId))
+		oldPeerIDs = append(oldPeerIDs, partyIDToNodeID(partyId))
 	}
 
 	return &eddsaReshareSession{
@@ -104,8 +104,11 @@ func NewEDDSAReshareSession(
 	}
 }
 
-func (s *eddsaReshareSession) GetExtraPeerIDs() []string {
-	// difference returns elements in A that are not in B.
+// GetLegacyCommitteePeers returns peer IDs that were part of the old committee
+// but are NOT part of the new committee after resharing.
+// These peers are still relevant during resharing because
+// they must send final share data to the new committee.
+func (s *eddsaReshareSession) GetLegacyCommitteePeers() []string {
 	difference := func(A, B []string) []string {
 		seen := make(map[string]bool)
 		for _, b := range B {

--- a/pkg/mpc/key_exchange_session.go
+++ b/pkg/mpc/key_exchange_session.go
@@ -31,6 +31,7 @@ type ECDHSession interface {
 	StartKeyExchange() error
 	BroadcastPublicKey() error
 	WaitForExchangeComplete() error
+	ErrChan() <-chan error
 	Close() error
 }
 
@@ -126,6 +127,10 @@ func (e *ecdhSession) StartKeyExchange() error {
 		return fmt.Errorf("failed to subscribe to ECDH topic: %w", err)
 	}
 	return nil
+}
+
+func (s *ecdhSession) ErrChan() <-chan error {
+	return s.errCh
 }
 
 func (s *ecdhSession) Close() error {

--- a/pkg/mpc/key_exchange_session.go
+++ b/pkg/mpc/key_exchange_session.go
@@ -73,9 +73,7 @@ func (e *ecdhSession) StartKeyExchange() error {
 		if ecdhMsg.From == e.nodeID {
 			return
 		}
-
 		logger.Info("Received ECDH message from", "node", ecdhMsg.From)
-
 		//TODO: consider how to avoid replay attack
 		if err := e.identityStore.VerifySignature(&ecdhMsg); err != nil {
 			e.errCh <- err
@@ -87,7 +85,6 @@ func (e *ecdhSession) StartKeyExchange() error {
 			e.errCh <- err
 			return
 		}
-		// Perform ECDH
 		sharedSecret, err := e.privateKey.ECDH(peerPublicKey)
 		if err != nil {
 			e.errCh <- err
@@ -99,9 +96,8 @@ func (e *ecdhSession) StartKeyExchange() error {
 		e.identityStore.SetSymmetricKey(ecdhMsg.From, symmetricKey)
 
 		requiredKeyCount := len(e.peerIDs) - 1
-
 		if e.identityStore.CheckSymmetricKeyComplete(requiredKeyCount) {
-			logger.Info("Completed ECDH!", "symmetricKeyAmount", requiredKeyCount)
+			logger.Info("Completed ECDH!", "symmetricKeyCount", requiredKeyCount)
 			logger.Info("PEER IS READY! Starting to accept MPC requests")
 		}
 	})

--- a/pkg/mpc/key_exchange_session.go
+++ b/pkg/mpc/key_exchange_session.go
@@ -17,12 +17,21 @@ import (
 
 	"encoding/json"
 
+	"sync"
+
 	"github.com/nats-io/nats.go"
+)
+
+const (
+	ECDHExchangeTopic   = "ecdh:exchange"
+	ECDHExchangeTimeout = 2 * time.Minute
 )
 
 type ECDHSession interface {
 	StartKeyExchange() error
 	BroadcastPublicKey() error
+	WaitForExchangeComplete() error
+	Close() error
 }
 
 type ecdhSession struct {
@@ -35,6 +44,8 @@ type ecdhSession struct {
 	publicKey        *ecdh.PublicKey
 	exchangeComplete chan struct{}
 	errCh            chan error
+	exchangeDone     bool
+	mu               sync.RWMutex
 }
 
 func NewECDHSession(
@@ -48,8 +59,8 @@ func NewECDHSession(
 		peerIDs:          peerIDs,
 		pubSub:           pubSub,
 		identityStore:    identityStore,
-		exchangeComplete: make(chan struct{}),
-		errCh:            make(chan error),
+		exchangeComplete: make(chan struct{}, 1),
+		errCh:            make(chan error, 1),
 	}
 }
 
@@ -64,7 +75,7 @@ func (e *ecdhSession) StartKeyExchange() error {
 	e.publicKey = privateKey.PublicKey()
 
 	// Subscribe to ECDH broadcast
-	sub, err := e.pubSub.Subscribe("ecdh:exchange", func(natMsg *nats.Msg) {
+	sub, err := e.pubSub.Subscribe(ECDHExchangeTopic, func(natMsg *nats.Msg) {
 		var ecdhMsg types.ECDHMessage
 		if err := json.Unmarshal(natMsg.Data, &ecdhMsg); err != nil {
 			return
@@ -96,22 +107,38 @@ func (e *ecdhSession) StartKeyExchange() error {
 		e.identityStore.SetSymmetricKey(ecdhMsg.From, symmetricKey)
 
 		requiredKeyCount := len(e.peerIDs) - 1
+		logger.Info("ECDH progress", "peer", ecdhMsg.From, "required", requiredKeyCount)
+
 		if e.identityStore.CheckSymmetricKeyComplete(requiredKeyCount) {
-			logger.Info("Completed ECDH!", "symmetricKeyCount", requiredKeyCount)
-			logger.Info("PEER IS READY! Starting to accept MPC requests")
+			logger.Info("Completed ECDH!", "symmetric key counts of peers", requiredKeyCount)
+			logger.Info("ALL PEERS ARE READY! Starting to accept MPC requests")
+
+			e.mu.Lock()
+			e.exchangeDone = true
+			e.mu.Unlock()
+
+			e.exchangeComplete <- struct{}{}
 		}
 	})
-	e.ecdhSub = sub
 
+	e.ecdhSub = sub
 	if err != nil {
 		return fmt.Errorf("failed to subscribe to ECDH topic: %w", err)
 	}
 	return nil
 }
 
+func (s *ecdhSession) Close() error {
+	err := s.ecdhSub.Unsubscribe()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (e *ecdhSession) BroadcastPublicKey() error {
 	publicKeyBytes := e.publicKey.Bytes()
-
 	msg := types.ECDHMessage{
 		From:      e.nodeID,
 		PublicKey: publicKeyBytes,
@@ -125,13 +152,30 @@ func (e *ecdhSession) BroadcastPublicKey() error {
 	msg.Signature = signature
 	signedMsgBytes, _ := json.Marshal(msg)
 
-	logger.Info("Starting to broadcast DH key")
-
-	if err := e.pubSub.Publish("ecdh:exchange", signedMsgBytes); err != nil {
+	logger.Info("Starting to broadcast DH key", "nodeID", e.nodeID)
+	if err := e.pubSub.Publish(ECDHExchangeTopic, signedMsgBytes); err != nil {
 		return fmt.Errorf("%s failed to publish DH message because %w", e.nodeID, err)
 	}
-
 	return nil
+}
+
+func (e *ecdhSession) WaitForExchangeComplete() error {
+	e.mu.RLock()
+	if e.exchangeDone {
+		e.mu.RUnlock()
+		return nil
+	}
+	e.mu.RUnlock()
+	timeout := time.After(ECDHExchangeTimeout) // 2 minutes timeout
+
+	select {
+	case <-e.exchangeComplete:
+		return nil
+	case err := <-e.errCh:
+		return err
+	case <-timeout:
+		return fmt.Errorf("ECDH exchange timeout!")
+	}
 }
 
 func deriveConsistentInfo(a, b string) []byte {

--- a/pkg/mpc/node.go
+++ b/pkg/mpc/node.go
@@ -482,6 +482,10 @@ func (p *Node) Close() {
 	}
 }
 
+func (p *Node) GetDHSession() ECDHSession {
+	return p.dhSession
+}
+
 func (p *Node) generatePreParams() []*keygen.LocalPreParams {
 	start := time.Now()
 	// Try to load from kvstore

--- a/pkg/mpc/node.go
+++ b/pkg/mpc/node.go
@@ -76,8 +76,7 @@ func NewNode(
 	start := time.Now()
 	elapsed := time.Since(start)
 	logger.Info("Starting new node, preparams is generated successfully!", "elapsed", elapsed.Milliseconds())
-
-	//each node initiates the DH key exchange listener at the beginning and invoke message sending when all peers are ready
+	// Each node initiates the DH key exchange listener at the beginning and invoke message sending when all peers are ready
 	dhSession := NewECDHSession(nodeID, peerIDs, pubSub, identityStore)
 	if err := dhSession.StartKeyExchange(); err != nil {
 		logger.Fatal("Failed to start DH key exchange", err)

--- a/pkg/mpc/node.go
+++ b/pkg/mpc/node.go
@@ -39,7 +39,7 @@ type Node struct {
 	identityStore  identity.Store
 
 	peerRegistry PeerRegistry
-	dhSession    ECDHSession
+	ecdhSession  ECDHSession
 }
 
 func NewNode(
@@ -70,7 +70,7 @@ func NewNode(
 		keyinfoStore:  keyinfoStore,
 		peerRegistry:  peerRegistry,
 		identityStore: identityStore,
-		dhSession:     dhSession,
+		ecdhSession:   dhSession,
 	}
 	node.ecdsaPreParams = node.generatePreParams()
 
@@ -425,8 +425,12 @@ func (p *Node) Close() {
 	}
 }
 
+func (p *Node) GetECDHSession() ECDHSession {
+	return p.ecdhSession
+}
+
 func (p *Node) GetDHSession() ECDHSession {
-	return p.dhSession
+	return p.ecdhSession
 }
 
 func (p *Node) generatePreParams() []*keygen.LocalPreParams {

--- a/pkg/mpc/node.go
+++ b/pkg/mpc/node.go
@@ -1,13 +1,9 @@
 package mpc
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"slices"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/bnb-chain/tss-lib/v2/ecdsa/keygen"
@@ -18,7 +14,6 @@ import (
 	"github.com/fystack/mpcium/pkg/kvstore"
 	"github.com/fystack/mpcium/pkg/logger"
 	"github.com/fystack/mpcium/pkg/messaging"
-	"github.com/google/uuid"
 )
 
 const (
@@ -44,23 +39,7 @@ type Node struct {
 	identityStore  identity.Store
 
 	peerRegistry PeerRegistry
-	dhSession    *ecdhSession
-}
-
-func PartyIDToRoutingDest(partyID *tss.PartyID) string {
-	return string(partyID.KeyInt().Bytes())
-}
-
-func PartyIDToNodeID(partyID *tss.PartyID) string {
-	return strings.Split(string(partyID.KeyInt().Bytes()), ":")[0]
-}
-
-func ComparePartyIDs(x, y *tss.PartyID) bool {
-	return bytes.Equal(x.KeyInt().Bytes(), y.KeyInt().Bytes())
-}
-
-func ComposeReadyKey(nodeID string) string {
-	return fmt.Sprintf("ready/%s", nodeID)
+	dhSession    ECDHSession
 }
 
 func NewNode(
@@ -435,44 +414,8 @@ func (p *Node) CreateReshareSession(
 	}
 }
 
-// generatePartyIDs generates the party IDs for the given purpose and version
-// It returns the self party ID and all party IDs
-// It also sorts the party IDs in place
-func (n *Node) generatePartyIDs(
-	label string,
-	readyPeerIDs []string,
-	version int,
-) (self *tss.PartyID, all []*tss.PartyID) {
-	// Pre-allocate slice with exact size needed
-	partyIDs := make([]*tss.PartyID, 0, len(readyPeerIDs))
-
-	// Create all party IDs in one pass
-	for _, peerID := range readyPeerIDs {
-		partyID := createPartyID(peerID, label, version)
-		if peerID == n.nodeID {
-			self = partyID
-		}
-		partyIDs = append(partyIDs, partyID)
-	}
-
-	// Sort party IDs in place
-	all = tss.SortPartyIDs(partyIDs, 0)
-	return
-}
-
-// createPartyID creates a new party ID for the given node ID, label and version
-// It returns the party ID: random string
-// Moniker: for routing messages
-// Key: for mpc internal use (need persistent storage)
-func createPartyID(nodeID string, label string, version int) *tss.PartyID {
-	partyID := uuid.NewString()
-	var key *big.Int
-	if version == BackwardCompatibleVersion {
-		key = big.NewInt(0).SetBytes([]byte(nodeID))
-	} else {
-		key = big.NewInt(0).SetBytes([]byte(nodeID + ":" + strconv.Itoa(version)))
-	}
-	return tss.NewPartyID(partyID, label, key)
+func ComposeReadyKey(nodeID string) string {
+	return fmt.Sprintf("ready/%s", nodeID)
 }
 
 func (p *Node) Close() {

--- a/pkg/mpc/node_test.go
+++ b/pkg/mpc/node_test.go
@@ -6,12 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPartyIDToNodeID(t *testing.T) {
-	partyID := createPartyID("4d8cb873-dc86-4776-b6f6-cf5c668f6468", "keygen", 1)
-	nodeID := PartyIDToRoutingDest(partyID)
-	assert.Equal(t, nodeID, "4d8cb873-dc86-4776-b6f6-cf5c668f6468:1", "NodeID should be equal")
-}
-
 func TestCreatePartyID_Structure(t *testing.T) {
 	sessionID := "test-session-123"
 	keyType := "keygen"
@@ -46,29 +40,6 @@ func TestCreatePartyID_DifferentVersions(t *testing.T) {
 	assert.NotEqual(t, partyID0.Key, partyID1.Key)
 }
 
-func TestPartyIDToRoutingDest_BackwardCompatible(t *testing.T) {
-	sessionID := "test-session-789"
-	keyType := "signing"
-
-	partyID := createPartyID(sessionID, keyType, BackwardCompatibleVersion)
-	nodeID := PartyIDToRoutingDest(partyID)
-
-	// For backward compatible version, should just be the sessionID
-	assert.Equal(t, sessionID, nodeID)
-}
-
-func TestPartyIDToRoutingDest_DefaultVersion(t *testing.T) {
-	sessionID := "test-session-999"
-	keyType := "signing"
-
-	partyID := createPartyID(sessionID, keyType, DefaultVersion)
-	nodeID := PartyIDToRoutingDest(partyID)
-
-	// For default version, should include the version number
-	expected := sessionID + ":1"
-	assert.Equal(t, expected, nodeID)
-}
-
 func TestCreatePartyID_EmptyValues(t *testing.T) {
 	// Test with empty session ID
 	partyID := createPartyID("", "keygen", 0)
@@ -79,22 +50,6 @@ func TestCreatePartyID_EmptyValues(t *testing.T) {
 	partyID = createPartyID("session", "", 1)
 	assert.NotNil(t, partyID)
 	assert.Equal(t, "", partyID.Moniker)
-}
-
-func TestPartyIDToRoutingDest_Consistency(t *testing.T) {
-	sessionID := "consistent-session"
-	keyType := "keygen"
-	version := 3
-
-	// Create the same party ID multiple times
-	partyID1 := createPartyID(sessionID, keyType, version)
-	partyID2 := createPartyID(sessionID, keyType, version)
-
-	nodeID1 := PartyIDToRoutingDest(partyID1)
-	nodeID2 := PartyIDToRoutingDest(partyID2)
-
-	// Should produce consistent results based on sessionID and version
-	assert.Equal(t, nodeID1, nodeID2, "Same parameters should produce same routing destinations")
 }
 
 func TestCreatePartyID_UniqueIDs(t *testing.T) {

--- a/pkg/mpc/party_id.go
+++ b/pkg/mpc/party_id.go
@@ -1,0 +1,71 @@
+package mpc
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/bnb-chain/tss-lib/v2/tss"
+	"github.com/google/uuid"
+)
+
+// generatePartyIDs generates the party IDs for the given purpose and version
+// It returns the self party ID and all party IDs
+// It also sorts the party IDs in place
+func (n *Node) generatePartyIDs(
+	label string,
+	readyPeerIDs []string,
+	version int,
+) (self *tss.PartyID, all []*tss.PartyID) {
+	// Pre-allocate slice with exact size needed
+	partyIDs := make([]*tss.PartyID, 0, len(readyPeerIDs))
+
+	// Create all party IDs in one pass
+	for _, peerID := range readyPeerIDs {
+		partyID := createPartyID(peerID, label, version)
+		if peerID == n.nodeID {
+			self = partyID
+		}
+		partyIDs = append(partyIDs, partyID)
+	}
+
+	// Sort party IDs in place
+	all = tss.SortPartyIDs(partyIDs, 0)
+	return
+}
+
+// createPartyID creates a new party ID for the given node ID, label and version
+// It returns the party ID: random string
+// Moniker: for routing messages
+// Key: for mpc internal use (need persistent storage)
+func createPartyID(nodeID string, label string, version int) *tss.PartyID {
+	partyID := uuid.NewString()
+	var key *big.Int
+	if version == BackwardCompatibleVersion {
+		key = new(big.Int).SetBytes([]byte(nodeID))
+	} else {
+		key = new(big.Int).SetBytes([]byte(fmt.Sprintf("%s:%d", nodeID, version)))
+	}
+	return tss.NewPartyID(partyID, label, key)
+}
+
+func partyIDToNodeID(partyID *tss.PartyID) string {
+	if partyID == nil {
+		return ""
+	}
+	nodeID, _, _ := strings.Cut(string(partyID.KeyInt().Bytes()), ":")
+	return strings.TrimSpace(nodeID)
+}
+
+func partyIDsToNodeIDs(pids []*tss.PartyID) []string {
+	out := make([]string, 0, len(pids))
+	for _, p := range pids {
+		out = append(out, partyIDToNodeID(p))
+	}
+	return out
+}
+
+func comparePartyIDs(x, y *tss.PartyID) bool {
+	return bytes.Equal(x.KeyInt().Bytes(), y.KeyInt().Bytes())
+}

--- a/pkg/mpc/session.go
+++ b/pkg/mpc/session.go
@@ -167,7 +167,7 @@ func (s *session) handleTssMessage(keyshare tss.Message) {
 }
 
 func (s *session) receiveP2PTssMessage(topic string, cipher []byte) {
-	senderID := extractSenderIdFromDirectTopic(topic)
+	senderID := extractSenderIDFromDirectTopic(topic)
 
 	if senderID == "" {
 		s.ErrCh <- fmt.Errorf("failed to extract senderID from direct topic: the direct topic format is wrong")
@@ -263,8 +263,8 @@ func (s *session) ListenToIncomingMessageAsync() {
 
 	//subscribe all possible p2p messages from all nodes, per the design of tss-lib, this includes oneself
 	toID := PartyIDToNodeID(s.selfPartyID)
-	for _, fromPartyId := range s.partyIDs {
-		fromID := PartyIDToNodeID(fromPartyId)
+	for _, fromPartyID := range s.partyIDs {
+		fromID := PartyIDToNodeID(fromPartyID)
 		topic := s.topicComposer.ComposeDirectTopic(fromID, toID)
 		sub, err := s.direct.Listen(topic, func(cipher []byte) {
 			go s.receiveP2PTssMessage(topic, cipher) // async for avoid timeout
@@ -280,8 +280,8 @@ func (s *session) ListenToIncomingMessageAsync() {
 func (s *session) ListenAsyncWithExtra(extraIDs []string) {
 	//subscribe potential p2p messages from addtional nodes (just for resharing)
 	toID := PartyIDToNodeID(s.selfPartyID)
-	for _, fromId := range extraIDs {
-		topic := s.topicComposer.ComposeDirectTopic(fromId, toID)
+	for _, fromID := range extraIDs {
+		topic := s.topicComposer.ComposeDirectTopic(fromID, toID)
 		sub, err := s.direct.Listen(topic, func(cipher []byte) {
 			go s.receiveP2PTssMessage(topic, cipher) // async for avoid timeout
 		})
@@ -364,10 +364,10 @@ func walletIDWithVersion(walletID string, version int) string {
 	return walletID
 }
 
-func extractSenderIdFromDirectTopic(topic string) string {
+func extractSenderIDFromDirectTopic(topic string) string {
 	strs := strings.Split(topic, ":")
 
-	// according to direct topic format, there will be 6 slices, senderId is the 4th one
+	// according to direct topic format, there will be 6 slices, senderID is the 4th one
 	if len(strs) == 6 {
 		return strs[3]
 	}

--- a/pkg/types/ecdh.go
+++ b/pkg/types/ecdh.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type ECDHMessage struct {
+	From      string    `json:"from"`
+	PublicKey []byte    `json:"public_key"`
+	Timestamp time.Time `json:"timestamp"`
+	Signature []byte    `json:"signature"`
+}
+
+// MarshalForSigning returns the deterministic JSON bytes for signing
+func (msg *ECDHMessage) MarshalForSigning() ([]byte, error) {
+	// Create a map with ordered keys
+	signingData := map[string]interface{}{
+		"from":      msg.From,
+		"publicKey": msg.PublicKey,
+		"timestamp": msg.Timestamp,
+	}
+
+	// Use json.Marshal with sorted keys
+	return json.Marshal(signingData)
+}

--- a/pkg/types/tss.go
+++ b/pkg/types/tss.go
@@ -1,11 +1,7 @@
-// The Licensed Work is (c) 2022 Sygma
-// SPDX-License-Identifier: LGPL-3.0-only
 package types
 
 import (
 	"encoding/json"
-	"sort"
-	"time"
 
 	"github.com/bnb-chain/tss-lib/v2/tss"
 )
@@ -21,13 +17,6 @@ type TssMessage struct {
 	IsToOldAndNewCommittees bool `json:"isToOldAndNewCommittees"`
 
 	Signature []byte `json:"signature"`
-}
-
-type ECDHMessage struct {
-	From      string    `json:"from"`
-	PublicKey []byte    `json:"public_key"`
-	Timestamp time.Time `json:"timestamp"`
-	Signature []byte    `json:"signature"`
 }
 
 func NewTssMessage(
@@ -119,19 +108,6 @@ func UnmarshalStartMessage(msgBytes []byte) (*StartMessage, error) {
 }
 
 // MarshalForSigning returns the deterministic JSON bytes for signing
-func (msg *ECDHMessage) MarshalForSigning() ([]byte, error) {
-	// Create a map with ordered keys
-	signingData := map[string]interface{}{
-		"From":      msg.From,
-		"PublicKey": msg.PublicKey,
-		"Timestamp": msg.Timestamp,
-	}
-
-	// Use json.Marshal with sorted keys
-	return json.Marshal(signingData)
-}
-
-// MarshalForSigning returns the deterministic JSON bytes for signing
 func (msg *TssMessage) MarshalForSigning() ([]byte, error) {
 	// Create a map with ordered keys
 	signingData := map[string]interface{}{
@@ -146,14 +122,4 @@ func (msg *TssMessage) MarshalForSigning() ([]byte, error) {
 
 	// Use json.Marshal with sorted keys
 	return json.Marshal(signingData)
-}
-
-// Helper function to get sorted party IDs
-func getPartyIDs(parties []*tss.PartyID) []string {
-	ids := make([]string, len(parties))
-	for i, party := range parties {
-		ids[i] = party.Id
-	}
-	sort.Strings(ids) // Ensure deterministic order
-	return ids
 }

--- a/pkg/types/tss_test.go
+++ b/pkg/types/tss_test.go
@@ -170,27 +170,3 @@ func TestUnmarshalStartMessage_InvalidJSON(t *testing.T) {
 	_, err := UnmarshalStartMessage(invalidJSON)
 	assert.Error(t, err)
 }
-
-func TestGetPartyIDs(t *testing.T) {
-	parties := []*tss.PartyID{
-		{
-			MessageWrapper_PartyID: &tss.MessageWrapper_PartyID{
-				Id: "party3",
-			},
-		},
-		{
-			MessageWrapper_PartyID: &tss.MessageWrapper_PartyID{
-				Id: "party1",
-			},
-		},
-		{
-			MessageWrapper_PartyID: &tss.MessageWrapper_PartyID{
-				Id: "party2",
-			},
-		},
-	}
-
-	ids := getPartyIDs(parties)
-	expected := []string{"party1", "party2", "party3"}
-	assert.Equal(t, expected, ids)
-}


### PR DESCRIPTION
## Changelog

### Added
- **AES-GCM utility functions** in `pkg/encryption/aes.go`:
  - `EncryptAESGCMWithNonceEmbed` – encrypts plaintext and embeds nonce in ciphertext.
  - `DecryptAESGCMWithNonceEmbed` – decrypts ciphertext with embedded nonce.
- **ECDH key exchange support** in `pkg/mpc/key_exchange_session.go` and `pkg/types/ecdh.go` with session management, error handling, and message flow.
- **Party ID utilities** in `pkg/mpc/party_id.go` for better ID and committee peer handling.
- `.gitignore` updated to exclude generated config files and node directories (`node0`, `node1`, `node2`, `config.yaml`).

### Changed
- **Node startup sequence** (`cmd/mpcium/main.go`):
  - Added ECDH key exchange before starting consumers.
  - Added error monitoring for ECDH session.
  - Improved context cancellation handling and graceful shutdown.
- **Resharing sessions**:
  - Renamed `GetExtraPeerIDs` → `GetLegacyCommitteePeers` in ECDSA/EdDSA sessions for clarity.
  - Updated consumer logic in `pkg/eventconsumer/event_consumer.go` to use new naming and behavior (`ListenToPeersAsync`).
- **Identity encryption** (`pkg/identity/identity.go`):
  - Removed inline AES-GCM encryption/decryption.
  - Switched to new `EncryptAESGCMWithNonceEmbed` / `DecryptAESGCMWithNonceEmbed` from `pkg/encryption`.
- **Messaging comments** clarified in `pkg/messaging/point2point.go`.
- **Keygen consumer logs** standardized to lowercase “keygen” for consistency.

### Removed
- Legacy AES-GCM functions `encryptAEAD` and `decryptAEAD` from `pkg/identity/identity.go`.
- Unused TSS-related types and tests (`pkg/types/tss.go`, `pkg/types/tss_test.go`).
- Old inline test and node setup code in `pkg/mpc/node_test.go` and `pkg/mpc/node.go`.
